### PR TITLE
Be explicit about scala version for Spray and make it provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,8 +135,9 @@
 
         <dependency>
             <groupId>io.spray</groupId>
-            <artifactId>spray-caching</artifactId>
+            <artifactId>spray-caching_2.10</artifactId>
             <version>${spray.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Newer versions of spray are built for multiple scala releases at the same time. If this project used `sbt` instead of Maven I would have updated it to also build for multiple scala releases at the same time.

We are using Scala 2.11 and so we need `spray-caching_2.11` in our project; we are hoping that marking it as `provided` here will work, but there is a good chance that it won't be perfect. We are testing this now.
